### PR TITLE
Add base asset filter into getTezExchangeRate

### DIFF
--- a/src/utils/tezos.ts
+++ b/src/utils/tezos.ts
@@ -55,7 +55,7 @@ export const getStorage = memoizee(
 
 const getTezExchangeRate = async () => {
   const marketTickers = await fetch<Array<ITicker>>('https://api.tzstats.com/markets/tickers');
-  const usdTickers = marketTickers.filter(e => e.quote === 'USD');
+  const usdTickers = marketTickers.filter(e => e.quote === 'USD' && e.base === 'XTZ');
   // price index: use all USD ticker last prices with equal weight
   const vol = usdTickers.reduce((s, t) => s + t.volume_base, 0) || null;
   const price = vol !== null && usdTickers.reduce((s, t) => s + (t.last * t.volume_base) / vol, 0);


### PR DESCRIPTION
Starting from this PR the XTZ exchange rate is going to be calculated properly:

<img width="393" alt="image" src="https://user-images.githubusercontent.com/6189971/217515661-328cc07d-463f-442a-b9f0-b190a3b977b2.png">
